### PR TITLE
Prepare package for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Keywords can be typed in manually or be found by ranking word occurrences in a p
 *arxiv-scan* was created by [Robert Glas](https://github.com/rmglas), [Simeon Doetsch](https://github.com/Simske), and [Martin Schlecker](https://github.com/matiscke).
 
 # Installation
-Requirements: Python >3.5
+Requirements: Python >=3.5
 
-These scripts can be installed with pip (or with [pipx]() for an isolated environment):
+These scripts can be installed with pip (or with [pipx](https://pypa.github.io/pipx/) for an isolated environment):
 ```
-pip install --upgrade git+https://github.com/matiscke/arxiv-scan.git
+pip install --upgrade arxiv-scan
 ```
 Depending on your Python installation, you might need one of the following:
 ```
-pip3 install --upgrade git+https://github.com/matiscke/arxiv-scan.git
-python3 -m pip install --upgrade git+https://github.com/matiscke/arxiv-scan
+pip3 install --upgrade arxiv-scan
+python3 -m pip install --upgrade arxiv-scan
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ Keywords can be typed in manually or be found by ranking word occurrences in a p
 # Installation
 Requirements: Python >=3.5
 
-These scripts can be installed with pip (or with [pipx](https://pypa.github.io/pipx/) for an isolated environment):
+## Using pip 
+We recommend to install the latest stable version of *arxiv-scan* using pip (or [pipx](https://pypa.github.io/pipx/) for an isolated environment):
 ```
-pip install --upgrade arxiv-scan
+pip install arxiv-scan
 ```
-Depending on your Python installation, you might need one of the following:
+:information_source:  Depending on your Python installation, you might instead need `pip3 install arxiv-scan` or `python3 -m pip install arxiv-scan`.
+
+## From source
+*arxiv-scan* is being developed on github. If you feel like hacking, feel free to install the latest version from there:
 ```
-pip3 install --upgrade arxiv-scan
-python3 -m pip install --upgrade arxiv-scan
+pip install --upgrade git+https://github.com/matiscke/arxiv-scan.git
 ```
+
+
 
 # Usage
 ## Query today's arXiV listing for relevant papers

--- a/publish-package.md
+++ b/publish-package.md
@@ -1,0 +1,37 @@
+# Publishing package on PyPI
+
+These are the steps for publishing the package on the [Python Package Index](https://pypi.org/).
+
+More detailed information can be found here: [Packaging Documentation](https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-the-package-files)
+
+## 1. Tagging the version
+This package uses `setuptools_scm` for version tagging from git tags.
+
+To create a new version, first a git tag has to be created either on the commandline:
+```
+git tag -a v0.1 -m "arxiv-scan v0.1"
+git push --tags
+```
+Or by creating a release in the Github interface.
+The Github release can also be created from the git tag.
+
+## 2. Build the package
+With this the package can be build using the `build`-package:
+```
+pip install --upgrade build
+python -m build .
+```
+
+## 3. Upload package to PyPI
+The package can now be uploaded to PyPI with `twine`:
+```
+pip install --upgrade twine
+```
+The login information (or tokens) can either be stored in a `.pypirc`-file, or this information will be prompted.
+[More info on the `.pypirc`-file.](https://packaging.python.org/en/latest/specifications/pypirc/)
+
+To upload the package:
+```
+python -m twine upload dist/*
+```
+Make sure to only upload the intended versions, so maybe customize the globbing (e.g. `python -m twine upload dist/arxiv-scan-0.1*`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Environment :: Console
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
+    License :: OSI Approved :: MIT License
 
 [options]
 packages = arxiv_scan

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,24 @@
 name = arxiv-scan
 author = Martin Schlecker
 author_email = schlecker@mpia.de
+maintainer = Simeon Doetsch
+maintainer_email = mail@simske.com
 url = https://github.com/matiscke/arxiv-scan
+description = Find preprints relevant to your individual research
+long_description = file: README.md
+long_description_content_type = text/markdown
+project_urls =
+    Bug Tracker = https://github.com/matiscke/arxiv-scan/issues
+classifiers =
+    Programming Language :: Python :: 3
+    Operating System :: OS Independent
+    Environment :: Console
+    Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Scientific/Engineering :: Physics
 
 [options]
 packages = arxiv_scan
+python_requires = >=3.5
 setup_requires =
     setuptools_scm
 install_requires =


### PR DESCRIPTION
For easier installation this should be published on PyPI, so the installation is as easy as `pip install arxiv-scan`.

I added some more metadata, I put you as the author and myself as the maintainer.
We also should choose a license, as Creative Commons isn't really used for code. I would just use the GPLv3, but you can check what you want: https://choosealicense.com/

I also added a quick reference how to upload the package.

I already uploaded `v0.1rc1` to PyPI, it is available here: https://pypi.org/project/arxiv-scan/
If you create a PyPI-account I can transfer the project to you.

Todo:
- [x] complete metadata
- [x] write publish instructions
- [x] choose license (#17)

