### PR TITLE
Build & Upload package with Github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Build package and upload to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        run: |
+          python -m build .
+      - name: Upload package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload dist/*
+      - name: Upload package to Github release
+        uses: alexellis/upload-assets@0.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_paths: '["./dist/*"]'


### PR DESCRIPTION
Github actions can automatically build and upload new package versions to PyPI when a Release is created.

This workflow triggers, when a release in the repo is created, and then:
- builds the wheel and sdist
- uploads the new versions to PyPI
- uploads the distribution files to the corresponding Github release

For the upload to PyPI a token has to be added as a repository secret (`PYPI_PASSWORD`). The Github token for the upload to the release will automatically created.

This is just a suggestion, if you're more comfortable with building and uploading manually that is also fine.