### PR TITLE
Add error message on connection failure

### DIFF
--- a/arxiv_scan/__main__.py
+++ b/arxiv_scan/__main__.py
@@ -140,11 +140,17 @@ def main():
     for category in categories:
         categories.extend(category_map.get(category, ()))
 
-    entries = get_entries(
-        categories, cutoff_date=cutoff_date,
-        cross_lists=config["show_cross_lists"],
-        resubmissions=config["show_resubmissions"]
-    )
+    try:
+        entries = get_entries(
+            categories, cutoff_date=cutoff_date,
+            cross_lists=config["show_cross_lists"],
+            resubmissions=config["show_resubmissions"]
+        )
+    except Exception as e:
+        print("Error while fetching feed:")
+        print(repr(e))
+        sys.exit(1)
+
     evaluate_entries(entries, keyword_ratings=config.keywords,
                      author_ratings=config.authors, rate_abstract=not args.ignore_abstract)
     entries = sort_entries(

--- a/arxiv_scan/parse.py
+++ b/arxiv_scan/parse.py
@@ -69,6 +69,9 @@ def get_entries(
             f"&sortBy={sortby}&sortOrder=descending"
             f"&start={start}&max_results={max_results}"
         )
+        # handle errors
+        if feed.bozo:
+            raise feed.bozo_exception
 
         if len(feed.entries) == 0:
             break


### PR DESCRIPTION
If a connection error occurs feedparser just returns an empty entrylist, without emitting the error . This PR fixes this and emits the error message.

Fixes #20