### PR TITLE
Fix typo in CLI help

### DIFF
--- a/arxiv_scan/__main__.py
+++ b/arxiv_scan/__main__.py
@@ -33,7 +33,7 @@ def parse_cli_arguments() -> tuple:
     parser.add_argument("-v", "--rating", type=int, default=None,
                         help="minimum rating for result list")
     parser.add_argument("-c", "--categories", default=None,
-                        help="arXiv subjects to scan, comma seperated list")
+                        help="arXiv subjects to scan, comma separated list")
     parser.add_argument("--reverse", action="store_true", default=None,
                         help="reverse list (lowest ranked paper on top)")
     parser.add_argument("--only-resubmissions", action="store_true", default=None,


### PR DESCRIPTION
## Summary
- correct 'comma seperated' to 'comma separated' in the categories help text

## Testing
- `python -m py_compile arxiv_scan/__main__.py`

------
https://chatgpt.com/codex/tasks/task_b_6887883b615083309568a6d6b484a6d3